### PR TITLE
Calculate event width based on number of columns in week view

### DIFF
--- a/components/event-calendar/week-view.tsx
+++ b/components/event-calendar/week-view.tsx
@@ -185,7 +185,7 @@ export function WeekView({
         currentColumn.push({ event, end: adjustedEnd })
 
         // Calculate width and left position based on number of columns
-        const width = columnIndex === 0 ? 1 : 0.9
+        const width = columnIndex === 0 ? 1 : 1 - (columnIndex * 0.1)
         const left = columnIndex === 0 ? 0 : columnIndex * 0.1
 
         positionedEvents.push({


### PR DESCRIPTION
# Tiny Update: Event Width Calculation

This pull request makes a very small, one-line change to the `WeekView` component, replacing the fixed event width of `0.9` for non-zero columns with a formula: `1 - (columnIndex * 0.1)`.

## Why?
- **Better Layout**: Events shrink progressively as their column index increases, helping reduce visual clutter in multi-column scenarios.

- **Simple Customization**: If we would however prefer to prevent columns from becoming too narrow, a minimum width could be set easily, something like:
  ```typescript
  const width = columnIndex === 0 ? 1 : Math.max(1 - (columnIndex * 0.1), 0.4);