### PR TITLE
Use addHours instead of custom helper function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,16 @@
 
 # dependencies
 /node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
 
 # next.js
 /.next/
@@ -10,13 +20,17 @@
 # production
 /build
 
+# misc
+.DS_Store
+*.pem
+
 # debug
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# env files
+# env files (can opt-in for committing if needed)
 .env*
 
 # vercel
@@ -25,3 +39,20 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env*.local
+
+# misc
+.deprecated
+data-examples
+
+# vscode
+.vscode/symbols.json
+
+# drizzle
+drizzle
+
+# certificates
+certificates
+
+# Turborepo
+.turbo

--- a/components/event-calendar/event-calendar.tsx
+++ b/components/event-calendar/event-calendar.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react"
 import { RiCalendarCheckLine } from "@remixicon/react"
 import {
   addDays,
+  addHours,
   addMonths,
   addWeeks,
   endOfWeek,
@@ -31,7 +32,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import {
-  addHoursToDate,
   AgendaDaysToShow,
   AgendaView,
   CalendarDndProvider,
@@ -163,7 +163,7 @@ export function EventCalendar({
       id: "",
       title: "",
       start: startTime,
-      end: addHoursToDate(startTime, 1),
+      end: addHours(startTime, 1),
       allDay: false,
     }
     setSelectedEvent(newEvent)

--- a/components/event-calendar/utils.ts
+++ b/components/event-calendar/utils.ts
@@ -141,12 +141,3 @@ export function getAgendaEventsForDay(
     })
     .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime())
 }
-
-/**
- * Add hours to a date
- */
-export function addHoursToDate(date: Date, hours: number): Date {
-  const result = new Date(date)
-  result.setHours(result.getHours() + hours)
-  return result
-}


### PR DESCRIPTION
This pull request includes several changes to the `components/event-calendar` files to streamline date manipulation by using a built-in method instead of a custom function.

### Codebase simplification:

* [`components/event-calendar/event-calendar.tsx`](diffhunk://#diff-c27d78d88a009c5f863a9aaa68dc41429a7c146eb487f7e4a137697b24e4d00fL166-R166): Replaced the custom `addHoursToDate` function with the `addHours` method from the date-fns library.
* [`components/event-calendar/utils.ts`](diffhunk://#diff-1ead4fad700ca9e27abb78c305dffa11e05bbeeb47f8efed0c5b947bc8e2208eL144-L152): Removed the `addHoursToDate` function as it is no longer needed.

### Imports update:

* [`components/event-calendar/event-calendar.tsx`](diffhunk://#diff-c27d78d88a009c5f863a9aaa68dc41429a7c146eb487f7e4a137697b24e4d00fR7): Added the `addHours` import and removed the `addHoursToDate` import to reflect the changes in date manipulation methods. [[1]](diffhunk://#diff-c27d78d88a009c5f863a9aaa68dc41429a7c146eb487f7e4a137697b24e4d00fR7) [[2]](diffhunk://#diff-c27d78d88a009c5f863a9aaa68dc41429a7c146eb487f7e4a137697b24e4d00fL34)